### PR TITLE
Paginate All account, add frequency to insights

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    facebook_ads (0.1.10)
+    facebook_ads (0.1.11)
       hashie (~> 3.4)
       rest-client (>= 1.6)
 
@@ -78,4 +78,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.7
+   1.14.3

--- a/facebook_ads.gemspec
+++ b/facebook_ads.gemspec
@@ -3,7 +3,7 @@
 # gem push facebook_ads-0.1.9.gem
 Gem::Specification.new do |s|
   s.name        = 'facebook_ads'
-  s.version     = '0.1.10'
+  s.version     = '0.1.11'
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
   s.authors     = ['Chris Estreich']

--- a/lib/facebook_ads/ad_account.rb
+++ b/lib/facebook_ads/ad_account.rb
@@ -6,7 +6,7 @@ module FacebookAds
 
     class << self
       def all
-        get('/me/adaccounts', objectify: true)
+        paginate('/me/adaccounts')
       end
 
       def find_by(conditions)

--- a/lib/facebook_ads/ad_insight.rb
+++ b/lib/facebook_ads/ad_insight.rb
@@ -4,7 +4,7 @@ module FacebookAds
   # https://developers.facebook.com/docs/marketing-api/insights/overview
   # https://developers.facebook.com/docs/marketing-api/insights/fields/v2.8
   class AdInsight < Base
-    FIELDS = %w(account_id campaign_id adset_id ad_id objective impressions unique_actions cost_per_unique_action_type clicks cpc cpm cpp ctr spend reach relevance_score).freeze
+    FIELDS = %w(account_id campaign_id adset_id ad_id objective impressions frequency unique_actions cost_per_unique_action_type clicks cpc cpm cpp ctr spend reach relevance_score).freeze
 
     class << self
       def find(_id)


### PR DESCRIPTION
I ran into a problem with FacebookAds::AdAccount.all only returning 25 accounts out of the 105 I have access to. I changed it from get to paginate and removed objectify, which is now correctly pulling all accounts. It seems to be working as normal, do you see any complications I might be missing here?

Also added frequency to the ad insights fields.